### PR TITLE
replace div instead of table

### DIFF
--- a/fe/static/js/refresh-table.js
+++ b/fe/static/js/refresh-table.js
@@ -9,9 +9,9 @@ define(['filter-app-table-by-name'], function (filter_app_table_by_name) {
           url: window.location.href,
           success: function (data) {
             if (data) {
-              var $table = $('table');
-              $table.after($(data).find('table'));
-              $table.remove();
+              var $table = $('#app-table');
+
+              $table.replaceWith($(data).find('#app-table'));
 
               filter_app_table_by_name.init();
             }

--- a/fe/templates/index.html
+++ b/fe/templates/index.html
@@ -32,6 +32,7 @@
   <div class="ui submit button hidden">Submit</div>
 </form>
 
+<div id="app-table">
 <table class="ui center aligned striped table">
   <thead class="large-only">
     <tr>
@@ -97,5 +98,6 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
replacing the inner table was causing datatable nesting with each
ajax refresh. This moves the replaced element one level out and
stops the nesting