### PR TITLE
Wristband 47 add healthcheck

### DIFF
--- a/fe/__init__.py
+++ b/fe/__init__.py
@@ -23,6 +23,7 @@ def create_app(config_object=None):
     app.add_url_rule('/login', view_func=views.do_login, methods=['POST'])
     app.add_url_rule('/logout', view_func=views.do_logout, methods=['GET'])
     app.add_url_rule('/deploy', view_func=views.do_deploy, methods=['POST'])
+    app.add_url_rule('/ping/ping', view_func=views.healthcheck, methods=['GET'])
     app.register_error_handler(WBAPIHTTPError, views.wb_error_handler)
     app.register_error_handler(Exception, views.generic_error_handler)
     app.before_request(get_api_before_request)

--- a/fe/views.py
+++ b/fe/views.py
@@ -88,3 +88,7 @@ def wb_error_handler(e):
         error["msg"] = e.response.text
 
     return render_template('error.html', error=error), status_code
+
+
+def healthcheck():
+    return ('', 200)

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -7,7 +7,7 @@ import requests
 class TestWBAPICase(TestCase):
     @patch('wb_api.requests.Session')
     def setUp(self, requests_session_mock):
-        self._api_uri = "http://dummy/api/"
+        self._api_uri = "http://dummy/"
         self._wb = WBAPI(self._api_uri)
         self._requests_session = requests_session_mock()
 
@@ -58,7 +58,7 @@ class TestWBAPICase(TestCase):
 
     def test_apps_hits_api(self):
         self._wb.get_apps()
-        self._requests_session.get.assert_called_with("{}apps/".format(self._api_uri),
+        self._requests_session.get.assert_called_with("{}api/apps/".format(self._api_uri),
                                                       timeout=(5, 30))
 
     @patch('wb_api.requests.Session')
@@ -66,7 +66,7 @@ class TestWBAPICase(TestCase):
         _wb = WBAPI(self._api_uri, connect_timeout=1, read_timeout=2)
         requests_session = requests_session_mock()
         _wb.get_apps()
-        requests_session.get.assert_called_with("{}apps/".format(self._api_uri),
+        requests_session.get.assert_called_with("{}api/apps/".format(self._api_uri),
                                                 timeout=(1, 2))
 
     def test_apps_transform(self):
@@ -125,7 +125,7 @@ class TestWBAPICase(TestCase):
     def test_deploy_app_hits_api(self):
         self._wb.deploy_app("app-1", "staging", "1.2.3")
         self._requests_session.put.assert_called_with(
-            "{}apps/app-1/stages/staging/version/1.2.3".format(self._api_uri),
+            "{}api/apps/app-1/stages/staging/version/1.2.3".format(self._api_uri),
             timeout=(5, 30))
 
     def test_get_session_cookies_returns_cookies(self):

--- a/tests/test_fe.py
+++ b/tests/test_fe.py
@@ -12,6 +12,10 @@ class TestFECase(TestCase):
         self.client = self.app.test_client()
         self.wbapi_mock = wbapi_mock
 
+    def test_healthcheck(self):
+        r = self.client.get('/ping/ping')
+        self.assertEquals(r.status_code, 200)
+
     #  Not sure why I need to do this after it's done in setUp??
     @patch('fe.WBAPI')
     def test_post_login_stores_api_cookies_and_username_in_session(self, wbapi_mock):


### PR DESCRIPTION
This is required as the previously used healthcheck `/api` passes through to the backend. We want to healthcheck the frontend in isolation.