### PR TITLE
handle 403s like 401s from wristband

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -12,21 +12,29 @@ class TestWBAPICase(TestCase):
         self._requests_session = requests_session_mock()
 
     def test_bad_login_raises_WBAPIUnauthorizedError_exception(self):
-        class BadResponse(object):
+        class Response401(object):
             status_code = 401
 
+        class Response403(object):
+            status_code = 403
+
         self._requests_session.post.return_value.raise_for_status.side_effect = \
-            requests.HTTPError(response=BadResponse())
+            requests.HTTPError(response=Response401())
         with self.assertRaises(WBAPIUnauthorizedError):
             self._wb.login("test_user", "test_password")
 
         self._requests_session.get.return_value.raise_for_status.side_effect = \
-            requests.HTTPError(response=BadResponse())
+            requests.HTTPError(response=Response401())
         with self.assertRaises(WBAPIUnauthorizedError):
             self._wb.get_apps()
 
         self._requests_session.put.return_value.raise_for_status.side_effect = \
-            requests.HTTPError(response=BadResponse())
+            requests.HTTPError(response=Response401())
+        with self.assertRaises(WBAPIUnauthorizedError):
+            self._wb.deploy_app("test-app", "test-stage", "test-version")
+
+        self._requests_session.put.return_value.raise_for_status.side_effect = \
+            requests.HTTPError(response=Response403())
         with self.assertRaises(WBAPIUnauthorizedError):
             self._wb.deploy_app("test-app", "test-stage", "test-version")
 

--- a/wb_api/__init__.py
+++ b/wb_api/__init__.py
@@ -19,7 +19,7 @@ def catch_api_http_exception(f):
         try:
             r = f(*args, **kwds)
         except WBAPIHTTPError as e:
-            if e.response.status_code == 401:
+            if e.response.status_code in [401, 403]:
                 raise WBAPIUnauthorizedError(response=e.response)
             else:
                 raise


### PR DESCRIPTION
SessionAuthentication in Django Rest returns 403s for not logged in users.
While this seems incorrect it's easier for now to just handle 403 and 401
the same.